### PR TITLE
Tuning retry based on ActiveJob Exceptions implementation

### DIFF
--- a/lib/quiq/job.rb
+++ b/lib/quiq/job.rb
@@ -17,10 +17,9 @@ module Quiq
 
           # Then load the definition of the job + its arguments
           klass = Object.const_get(payload['job_class'])
-          args = payload['arguments']
 
           # Then run the task
-          klass.new.perform(*args)
+          klass.deserialize(payload).perform_now
         rescue JSON::ParserError => e
           Quiq.logger.warn("Invalid format: #{e}")
           send_to_dlq(@raw, e)

--- a/testapp/app/jobs/test_job.rb
+++ b/testapp/app/jobs/test_job.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 class TestJob < ApplicationJob
+  class CustomError < StandardError; end
+
+  retry_on(CustomError, wait: 5, attempts: 3, queue: :retry) do
+    raise
+  end
+
   def perform(data, wait)
     puts "[Worker ##{$$}] Receiving new job: #{data}"
     Quiq.current_task.sleep wait
     puts "[Worker ##{$$}] Time to wake up after #{wait} seconds"
+    raise CustomError, 'Caught CustomError'
   end
 end


### PR DESCRIPTION
ActiveJob has a built-in retry mechanism.
https://github.com/rails/rails/blob/6-0-stable/activejob/lib/active_job/exceptions.rb

By deserializing the job message properly, we can get the retry working easily with Quiq.